### PR TITLE
Changed prefix to match current encoding format

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ async def homepage(request):
     keywords = " ".join([v.replace(' ', '-').strip() for k, v in params.items()
                          if 'key' in k and v != ''])
 
-    prepend = "<|startoftext|>~`{}~^{}~@".format(subreddit, keywords)
+    prepend = "<|startoftext|>~`{}~^{}~".format(subreddit, keywords) + "}"
     text = prepend + params.get('prefix', '')[:100]
 
     length = MIN_LENGTH


### PR DESCRIPTION
# Description

The format of the startoftext tag to match the format encoded in the current commit of gpt-2-keyword-generation at https://github.com/minimaxir/gpt-2-keyword-generation/commit/fe421e1ea010938b7335af409d0bf508c9902892

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've tested this on a copy of GPT-2 that is trained on love letters (the prefix is in bold, and keywords were used). Here is the text output before:

"**my love for you is like a hurricane** that consumes mexico~}I am consumed by the desire to be with you, to talk to you and to feel you near me."

Notice that after the prefix, there is a "~}" that is generated. This is because the old way the startoftext was built up used a "@" insteald of "}" to end the startoftext block. So the model would finish the startoftext block, which is undesired behaviour

Here is the text output after:

"**I've been in denial about my love for you.** Every day I fight a battle with myself in which my heart says I should tell you how I feel"

# Checklist:
- [x] My changes generate no new warnings
